### PR TITLE
Add git sync-branches alias to clean up stale local branches

### DIFF
--- a/modules/home-manager/apps/git.nix
+++ b/modules/home-manager/apps/git.nix
@@ -22,6 +22,7 @@
       amend = "commit --amend";
       unstage = "reset HEAD --";
       last = "log -1 HEAD";
+      sync-branches = "!git fetch --prune && git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D";
     };
     
     ignores = [


### PR DESCRIPTION
Added 'git sync-branches' alias that:
- Fetches from remote and prunes deleted branches (git fetch --prune)
- Finds local branches whose remote has been deleted (grep ': gone]')
- Extracts branch names (awk)
- Deletes those local branches (git branch -D)

Usage:
  git sync-branches

This is useful for cleaning up local branches after pull requests have been merged and deleted on the remote repository.