### PR TITLE
Add zion Mac Mini configuration for maker/craft station

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,19 @@
           machineName = "Mac Mini";
         };
 
+        # Zion - Maker/craft station (3D printing, CAD, design)
+        "zion" = mkDarwinSystem {
+          hostname = "zion";
+          machineType = "macmini";
+          machineName = "Zion";
+          username = "batman";
+          extraModules = [
+            ./hosts/profiles/dev.nix       # Development tools
+            ./hosts/profiles/work.nix      # Work collaboration apps
+            ./hosts/profiles/personal.nix  # Media tools for tutorials/streaming
+          ];
+        };
+
         # VM configurations
         "vm-test" = mkDarwinSystem {
           hostname = "vm-test";

--- a/hosts/machines/zion/default.nix
+++ b/hosts/machines/zion/default.nix
@@ -1,0 +1,39 @@
+{ pkgs, config, lib, ... }:
+
+{
+  # Zion - Mac Mini maker/craft station
+  # Named after the last human city in The Matrix trilogy
+
+  imports = [
+    # Import Mac Mini base configuration
+    ../../types/macmini/default.nix
+  ];
+
+  # Maker/craft specific applications
+  apps = {
+    useBaseLists = true;
+
+    # 3D printing and design apps
+    casksToAdd = [
+      # 3D Printing
+      "bambu-studio"          # Bambu Lab slicer
+
+      # CAD/Design
+      "autodesk-fusion"       # Fusion 360
+      "openscad"              # Programmable CAD
+
+      # Note: Cricut Design Space is not available via Homebrew
+      # Install manually from: https://design.cricut.com/
+    ];
+
+    # Design-related CLI tools
+    systemPackagesToAdd = [
+      "openscad"              # OpenSCAD CLI for scripted models
+    ];
+  };
+
+  # Environment for maker projects
+  environment.variables = {
+    MAKER_PROJECTS = "$HOME/Maker";
+  };
+}


### PR DESCRIPTION
- Create hosts/machines/zion with 3D printing and CAD apps
- Includes: bambu-studio, autodesk-fusion, openscad
- Note: Cricut Design Space not available via Homebrew (manual install)
- Full-stack profiles: dev + work + personal (Mac Mini is powerful)

Named after the last human city in The Matrix trilogy.